### PR TITLE
Close the AudioContext on stop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1256,9 +1256,9 @@
       }
     },
     "@types/jest": {
-      "version": "24.0.18",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.18.tgz",
-      "integrity": "sha512-jcDDXdjTcrQzdN06+TSVsPPqxvsZA/5QkYfIZlq1JMw7FdP5AZylbOc+6B/cuDurctRe+MziUMtQ3xQdrbjqyQ==",
+      "version": "24.0.19",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.19.tgz",
+      "integrity": "sha512-YYiqfSjocv7lk5H/T+v5MjATYjaTMsUkbDnjGqSMoO88jWdtJXJV4ST/7DKZcoMHMBvB2SeSfyOzZfkxXHR5xg==",
       "dev": true,
       "requires": {
         "@types/jest-diff": "*"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@semantic-release/git": "7.0.16",
     "@types/dom-mediacapture-record": "1.0.1",
-    "@types/jest": "24.0.18",
+    "@types/jest": "24.0.19",
     "bundlesize": "0.18.0",
     "concurrently": "5.0.0",
     "jest": "24.9.0",


### PR DESCRIPTION
Browsers have limits on how many AudioContexts are open. Safari only 4, Chrome 30. We need to close the AudioContexts on stop if we need to start new recordings.